### PR TITLE
Added FLAG_WINDOW_UNFOCUSED

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -158,7 +158,7 @@ uint32_t main(void)
 	ctx->running = true;
 	MTY_Thread *thread = MTY_ThreadCreate((MTY_ThreadFunc) work_thread, ctx);
 
-	SetConfigFlags(FLAG_WINDOW_UNDECORATED | FLAG_WINDOW_TRANSPARENT | FLAG_MSAA_4X_HINT | FLAG_VSYNC_HINT);
+	SetConfigFlags(FLAG_WINDOW_UNDECORATED | FLAG_WINDOW_TRANSPARENT | FLAG_MSAA_4X_HINT | FLAG_VSYNC_HINT | FLAG_WINDOW_UNFOCUSED);
 	InitWindow(1, 1, "RayVector");
 	SetFlags(GetWindowHandle());
 


### PR DESCRIPTION
Added the FLAG_WINDOW_UNFOCUSED to make sure visualizer will stay in the back out of focus and not end up on top of the taskbar (ex: for people who have a transparent taskbar).